### PR TITLE
Add a new revision to a data set using data in S3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Examples of interacting with the AWS Data Exchange API from the data provider si
 
 * [create-data-set-with-finalized-revision](providers/ruby/create-data-set-with-finalized-revision): Create a data set with a finalized revision.
 * [enumerate-data-products](providers/ruby/enumerate-data-products): Enumerate data products, examine each product's data sets, and fetch the data set.
+* [add-revision-to-a-data-set](providers/ruby/add-revision-to-a-data-set): Add a new revision to a data set using data in S3.
+
+## API References
+
+* [AWS Data Exchange API](https://docs.aws.amazon.com/data-exchange/latest/apireference/welcome.html)
+* [AWS Marketplace Catalog API](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/welcome.html)
 
 ## License
 

--- a/providers/ruby/add-revision-to-a-data-set/Gemfile
+++ b/providers/ruby/add-revision-to-a-data-set/Gemfile
@@ -1,0 +1,5 @@
+source 'http://rubygems.org'
+
+gem 'aws-sdk-dataexchange'
+gem 'aws-sdk-marketplacecatalog'
+gem 'time_ago_in_words'

--- a/providers/ruby/add-revision-to-a-data-set/Gemfile.lock
+++ b/providers/ruby/add-revision-to-a-data-set/Gemfile.lock
@@ -1,0 +1,31 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    aws-eventstream (1.0.3)
+    aws-partitions (1.269.0)
+    aws-sdk-core (3.89.1)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-dataexchange (1.0.0)
+      aws-sdk-core (~> 3, >= 3.71.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-marketplacecatalog (1.0.0)
+      aws-sdk-core (~> 3, >= 3.71.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.1.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+    jmespath (1.4.0)
+    time_ago_in_words (0.1.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  aws-sdk-dataexchange
+  aws-sdk-marketplacecatalog
+  time_ago_in_words
+
+BUNDLED WITH
+   2.1.4

--- a/providers/ruby/add-revision-to-a-data-set/README.md
+++ b/providers/ruby/add-revision-to-a-data-set/README.md
@@ -1,0 +1,17 @@
+# Add a New Revision to a Data Set
+
+This sample adds a new finalized revision to a data set using data in S3 by combining the [AWS Marketplace Catalog API](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/welcome.html) and the [AWS Data Exchange API](https://docs.aws.amazon.com/data-exchange/latest/apireference/welcome.html).
+
+To run the sample, set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION` and `ENTITY_ID` that identifies the product that contains a data set to add a revision to. You can enumerate [owned data products](https://console.aws.amazon.com/dataexchange/home?region=us-east-1#/owned/products) using the [enumerate-data-products sample](../enumerate-data-products) to get this ID.
+
+```
+$ ENTITY_ID=prod-... bundle exec ruby add-revision-to-a-data-set.rb
+
+6c6becda6a8fb086b945bbf1dca4e1f5: Junto Heartbeat updated 1 minute and 15 seconds ago
+Created revision 3e6d60894e5e3bee5c528d0ef5268f71
+Importing aws-samples-create-data-set-with-finalized-revision/data.txt from S3 ............. done.
+The revision 3e6d60894e5e3bee5c528d0ef5268f71 has been finalized.
+Started change set 2jqqse6runsgfz8uej5e2mpq6 ............ done.
+Change set 2jqqse6runsgfz8uej5e2mpq6 published.
+Done.
+```

--- a/providers/ruby/add-revision-to-a-data-set/add-revision-to-a-data-set.rb
+++ b/providers/ruby/add-revision-to-a-data-set/add-revision-to-a-data-set.rb
@@ -1,0 +1,139 @@
+require 'aws-sdk-dataexchange'
+require 'aws-sdk-marketplacecatalog'
+require 'time_ago_in_words'
+
+Aws.config.update({
+  region: ENV['AWS_REGION'] || 'us-east-1',
+  credentials: Aws::Credentials.new(
+    ENV['AWS_ACCESS_KEY_ID'], 
+    ENV['AWS_SECRET_ACCESS_KEY'],
+    ENV['AWS_SESSION_TOKEN']
+  )
+})
+
+catalog_name = 'AWSMarketplace'
+entity_id = ENV['ENTITY_ID'] || raise("missing ENV['ENTITY_ID']")
+
+catalog = Aws::MarketplaceCatalog::Client.new
+
+# describe a specific entity
+
+described_entity = catalog.describe_entity(catalog: catalog_name, entity_id: entity_id)
+described_entity_details = JSON.parse(described_entity.details)
+
+# first data set
+data_set = described_entity_details['DataSets'].first
+raise 'Missing Data Set' unless data_set
+
+data_set_name = data_set['Name']
+data_set_arn = data_set['DataSetArn']
+data_set_id = Aws::ARNParser.parse(data_set_arn).resource.split('/').last
+data_set_last_revision_added_at = DateTime.parse(data_set['LastRevisionAddedDate'])
+puts "#{data_set_id}: #{data_set_name} updated #{data_set_last_revision_added_at.to_time.ago_in_words}"
+
+# create a revision and finalize it
+dx = Aws::DataExchange::Client.new
+
+revision = dx.create_revision(
+  data_set_id: data_set_id,
+  comment: 'New revision in the Data Set.'
+)
+
+puts "Created revision #{revision.id}"
+
+# import data from S3
+
+s3_bucket_name = 'aws-samples-create-data-set-with-finalized-revision'
+s3_data_key = 'data.txt'
+
+STDOUT.write "Importing #{s3_bucket_name}/#{s3_data_key} from S3 ..."
+
+export_job = dx.create_job(
+  type: 'IMPORT_ASSETS_FROM_S3',
+  details: {
+    import_assets_from_s3: {
+      asset_sources: [
+        bucket: s3_bucket_name,
+        key: s3_data_key
+      ],
+      data_set_id: data_set_id,
+      revision_id: revision.id
+    }
+  }
+)
+
+dx.start_job(job_id: export_job.id)
+
+loop do
+  sleep 1
+  job_in_progress = dx.get_job(job_id: export_job.id)
+  STDOUT.write('.')
+  state = job_in_progress.state
+  next if state == 'IN_PROGRESS' || state == 'WAITING'
+  break if state == 'COMPLETED'
+  raise job_in_progress.errors.join(&:to_s) if job_in_progress.state == 'ERROR'
+  raise job_in_progress.state
+end
+
+puts ' done.'
+
+# finalize the revision
+
+dx.update_revision(
+  data_set_id: data_set_id,
+  revision_id: revision.id,
+  finalized: true
+)
+
+# get the revision
+
+finalized_revision = dx.get_revision(
+  data_set_id: data_set_id,
+  revision_id: revision.id
+)
+
+puts "The revision #{revision.id} has #{finalized_revision.finalized ? 'been finalized' : 'not been finalized'}."
+
+# add a finalized revision to the data set
+
+start_change_set = catalog.start_change_set(
+  catalog: 'AWSMarketplace',
+  change_set_name: "Adding revision to #{data_set_name}.",
+  change_set:[
+    {
+      change_type: 'AddRevisions',
+      entity: {
+        identifier: described_entity.entity_identifier,
+        type: described_entity.entity_type
+      },
+      details: JSON.dump({
+        'DataSetArn' => data_set_arn,
+        'RevisionArns' => [finalized_revision.arn]
+      })
+    }
+  ]
+)
+
+STDOUT.write "Started change set #{start_change_set.change_set_id} ..."
+
+chage_set_id = start_change_set.change_set_id
+loop do
+  sleep 1
+
+  describe_change_set = catalog.describe_change_set(
+    catalog: 'AWSMarketplace',
+    change_set_id: chage_set_id
+  )
+
+  describe_change_set_status = describe_change_set.status
+  break if describe_change_set_status == 'SUCCEEDED'
+  raise "#{describe_change_set.failure_description}\n#{describe_change_set
+    .change_set.first.error_detail_list
+    .map(&:error_message).join}" if describe_change_set_status == 'FAILED'
+
+  STDOUT.write('.')
+end
+puts ' done.'
+
+puts "Change set #{chage_set_id} published."
+puts "Done."

--- a/providers/ruby/create-data-set-with-finalized-revision/create-data-set-with-finalized-revision.rb
+++ b/providers/ruby/create-data-set-with-finalized-revision/create-data-set-with-finalized-revision.rb
@@ -9,8 +9,8 @@ Aws.config.update({
   )
 })
 
-s3_bucket_name = 'bucket'
-s3_data_key = 'file.txt'
+s3_bucket_name = 'aws-samples-create-data-set-with-finalized-revision'
+s3_data_key = 'data.txt'
 
 dx = Aws::DataExchange::Client.new
 
@@ -89,6 +89,10 @@ puts "The revision #{revision.id} has #{finalized_revision.finalized ? 'been fin
 
 # cleanup
 
+puts "Cleaning up, deleting data set."
+
 dx.delete_data_set(
   data_set_id: data_set.id
 )
+
+puts "Done."


### PR DESCRIPTION
Closes #19.  

Adds a new revision to a data set using data in S3 with CAPI and DX APIs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
