### PR TITLE
Publish a data set into a product.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Examples of interacting with the AWS Data Exchange API from the data provider si
 ### Ruby
 
 * [create-data-set-with-finalized-revision](providers/ruby/create-data-set-with-finalized-revision): Create a data set with a finalized revision.
-* [enumerate-data-products](providers/ruby/enumerate-data-products): Enumerate data products, examine each product's data sets, and fetch the data set.
+* [enumerate-data-products](providers/ruby/enumerate-data-products): Enumerate data products, examine each product's data sets, and fetch a data set.
+* [add-data-set](providers/ruby/add-data-set): Create and publish a data set into an existing product.
 * [add-revision-to-a-data-set](providers/ruby/add-revision-to-a-data-set): Add a new revision to a data set using data in S3.
 
 ## API References

--- a/providers/ruby/add-data-set/Gemfile
+++ b/providers/ruby/add-data-set/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source 'http://rubygems.org'
+
+gem 'aws-sdk-dataexchange'
+gem 'aws-sdk-marketplacecatalog'

--- a/providers/ruby/add-data-set/Gemfile.lock
+++ b/providers/ruby/add-data-set/Gemfile.lock
@@ -1,0 +1,29 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    aws-eventstream (1.1.0)
+    aws-partitions (1.373.0)
+    aws-sdk-core (3.107.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-dataexchange (1.9.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-marketplacecatalog (1.7.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.2)
+      aws-eventstream (~> 1, >= 1.0.2)
+    jmespath (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  aws-sdk-dataexchange
+  aws-sdk-marketplacecatalog
+
+BUNDLED WITH
+   2.1.4

--- a/providers/ruby/add-data-set/README.md
+++ b/providers/ruby/add-data-set/README.md
@@ -1,0 +1,15 @@
+# Add a New Data Set to a Published Product
+
+This sample creates and publishes a new data set by combining the [AWS Marketplace Catalog API](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/welcome.html)'s [AddDataSets](https://docs.aws.amazon.com/es_es/data-exchange/latest/userguide/add-data-sets.html) change set, and the [AWS Data Exchange API](https://docs.aws.amazon.com/data-exchange/latest/apireference/welcome.html).
+
+To run the sample, set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION` and `ENTITY_ID` that identifies the product in which to publish a data set. You can enumerate [owned data products](https://console.aws.amazon.com/dataexchange/home?region=us-east-1#/owned/products) using the [enumerate-data-products sample](../enumerate-data-products) to get this ID.
+
+```
+$ ENTITY_ID=prod-... bundle exec ruby add-data-set.rb
+
+Created a new Data Set 97267ce8224e3cae6286075d703f9e7f called "aws-dataexchange-api-samples test".
+Adding Data Set arn:aws:dataexchange:us-east-1:147854383891:data-sets/97267ce8224e3cae6286075d703f9e7f to "prod-jrcarqhoeypfs@11".
+Started change set a0z6l4wsl7jn5azcsjzy86zcl ................ done.
+Change set a0z6l4wsl7jn5azcsjzy86zcl published.
+Done.
+```

--- a/providers/ruby/add-data-set/add-data-set.rb
+++ b/providers/ruby/add-data-set/add-data-set.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'aws-sdk-dataexchange'
+require 'aws-sdk-marketplacecatalog'
+
+Aws.config.update(
+  region: ENV['AWS_REGION'] || 'us-east-1',
+  credentials: Aws::Credentials.new(
+    ENV['AWS_ACCESS_KEY_ID'],
+    ENV['AWS_SECRET_ACCESS_KEY'],
+    ENV['AWS_SESSION_TOKEN']
+  )
+)
+
+dx = Aws::DataExchange::Client.new
+
+# create a Data Set
+
+data_set = dx.create_data_set(
+  asset_type: 'S3_SNAPSHOT',
+  name: 'aws-dataexchange-api-samples test',
+  description: 'Test Data Set for aws-dataexchange-api-samples.',
+  tags: {
+    category: 'demo',
+    language: 'ruby'
+  }
+)
+
+puts "Created a new Data Set #{data_set.id} called \"#{data_set.name}\"."
+
+catalog_name = 'AWSMarketplace'
+entity_id = ENV['ENTITY_ID'] || raise("missing ENV['ENTITY_ID']")
+
+catalog = Aws::MarketplaceCatalog::Client.new
+
+# describe the product entity in the AWS Marketplace catalog
+
+described_entity = catalog.describe_entity(catalog: catalog_name, entity_id: entity_id)
+described_entity_details = JSON.parse(described_entity.details)
+
+# add the new data set to the product
+puts "Adding Data Set #{data_set.arn} to \"#{described_entity.entity_identifier}\"."
+
+start_change_set = catalog.start_change_set(
+  catalog: 'AWSMarketplace',
+  change_set_name: "Publishing data set to #{entity_id}.",
+  change_set: [
+    {
+      change_type: 'AddDataSets',
+      entity: {
+        identifier: described_entity.entity_identifier,
+        type: described_entity.entity_type
+      },
+      details: JSON.dump(
+        'DataSets' => [
+          { 'Arn' => data_set.arn }
+        ]
+      )
+    }
+  ]
+)
+
+STDOUT.write "Started change set #{start_change_set.change_set_id} ..."
+
+chage_set_id = start_change_set.change_set_id
+loop do
+  sleep 1
+
+  describe_change_set = catalog.describe_change_set(
+    catalog: 'AWSMarketplace',
+    change_set_id: chage_set_id
+  )
+
+  describe_change_set_status = describe_change_set.status
+  break if describe_change_set_status == 'SUCCEEDED'
+
+  if describe_change_set_status == 'FAILED'
+    raise "#{describe_change_set.failure_description}\n#{describe_change_set
+      .change_set.first.error_detail_list
+      .map(&:error_message).join}"
+  end
+
+  STDOUT.write('.')
+end
+puts ' done.'
+
+puts "Change set #{chage_set_id} published."
+puts 'Done.'

--- a/providers/ruby/add-revision-to-a-data-set/README.md
+++ b/providers/ruby/add-revision-to-a-data-set/README.md
@@ -1,6 +1,6 @@
 # Add a New Revision to a Data Set
 
-This sample adds a new finalized revision to a data set using data in S3 by combining the [AWS Marketplace Catalog API](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/welcome.html) and the [AWS Data Exchange API](https://docs.aws.amazon.com/data-exchange/latest/apireference/welcome.html).
+This sample adds a new finalized revision to a data set using data in S3 by combining the [AWS Marketplace Catalog API](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/welcome.html)'s [AddRevisions](https://docs.aws.amazon.com/es_es/data-exchange/latest/userguide/add-revisions.html) change set, and the [AWS Data Exchange API](https://docs.aws.amazon.com/data-exchange/latest/apireference/welcome.html).
 
 To run the sample, set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION` and `ENTITY_ID` that identifies the product that contains a data set to add a revision to. You can enumerate [owned data products](https://console.aws.amazon.com/dataexchange/home?region=us-east-1#/owned/products) using the [enumerate-data-products sample](../enumerate-data-products) to get this ID.
 


### PR DESCRIPTION
Added a sample that uses [AddDataSets](https://docs.aws.amazon.com/es_es/data-exchange/latest/userguide/add-data-sets.html) since [we released it](https://aws.amazon.com/about-aws/whats-new/2020/08/aws-data-exchange-now-supports-adding-data-sets-to-existing-products/).

<img width="1072" alt="Screen Shot 2020-09-21 at 12 48 00 PM" src="https://user-images.githubusercontent.com/542335/93796357-ba138200-fc08-11ea-86d1-bc43ebc71b3c.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
