### PR TITLE
add scripts - add-amazon-s3-data-files and create-amazon-s3-files-data-grant

### DIFF
--- a/providers/python/add-amazon-s3-data-files/README.md
+++ b/providers/python/add-amazon-s3-data-files/README.md
@@ -1,0 +1,55 @@
+# Add Amazon S3 Files Dataset (Python)
+
+This script automates the process of creating and populating AWS Data Exchange datasets using content from Amazon S3 buckets. It creates a new dataset, generates a revision, and imports specified assets (either entire buckets, prefixes, or individual objects) into the revision. The script provides a simple command-line interface, allowing users to easily specify the source S3 bucket, dataset name, and desired assets, streamlining the process of preparing data for distribution through AWS Data Exchange.
+
+### Setup
+
+Install the requirements:
+
+```bash
+$ pip3 install -r requirements.txt
+```
+
+Set the AWS access key and secret environment variables:
+
+```
+$ export AWS_ACCESS_KEY_ID=<your-access-key-id>
+$ export AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
+$ export AWS_SESSION_TOKEN=<your-session-token>
+```
+
+The user needs the **AWSDataExchangeProviderFullAccess** IAM policy associated with your role/account. Find out more
+about IAM policies on AWS Data Exchange [here](https://docs.aws.amazon.com/data-exchange/latest/userguide/auth-access.html).
+
+The user needs to list and read objects from the specified S3 bucket. You'll need the following S3 permissions:
+- s3:GetObject
+- s3:ListBucket
+
+Here's a sample IAM policy that includes the necessary permissions:
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::your-bucket-name",
+                "arn:aws:s3:::your-bucket-name/*"
+            ]
+        }
+    ]
+}
+```
+### Example Usage
+
+Get usage help: `python3 add-amazon-s3-files.py --help`
+
+Create dataset and import all files from an Amazon S3 Bucket: `python3 add-amazon-s3-files.py --dataset-name example_dataset --bucket example_bucket`
+
+Create dataset and import files from specific prefix(es) within an Amazon S3 Bucket:`python3 add-amazon-s3-files.py --dataset-name example_prefix_dataset --bucket example_bucket --prefix data/`
+
+Create dataset and import specific file(s) from an Amazon S3 bucket: `python3 add-amazon-s3-files.py --dataset-name example_file_dataset --bucket example_bucket --key data/titanic.parquet`

--- a/providers/python/add-amazon-s3-data-files/add-amazon-s3-files.py
+++ b/providers/python/add-amazon-s3-data-files/add-amazon-s3-files.py
@@ -1,0 +1,173 @@
+import boto3
+import time
+import click
+from botocore.exceptions import ClientError
+
+def create_dataset(dataexchange, dataset_name):
+    """
+    Create a data files delivery method dataset
+    """
+    try:
+        dataset_params = {
+            'AssetType': 'S3_SNAPSHOT',
+            'Description': f'Dataset for {dataset_name}',
+            'Name': dataset_name,
+            'Tags': {
+                'Source': 'S3'
+            }
+        }
+
+        response = dataexchange.create_data_set(**dataset_params)
+        return response['Id']
+    except ClientError as e:
+        click.echo(f"An error occurred while creating the dataset: {e}", err=True)
+        raise
+
+def create_revision(dataexchange, dataset_id):
+    """
+    Create a new revision for the dataset
+    """
+    try:
+        response = dataexchange.create_revision(DataSetId=dataset_id)
+        return response['Id']
+    except ClientError as e:
+        click.echo(f"An error occurred while creating the revision: {e}", err=True)
+        raise
+
+def add_asset_to_revision(dataexchange, dataset_id, revision_id, bucket, prefixes, keys):
+    """
+    Add assets to the revision based on prefixes and keys, or entire bucket if none specified
+    """
+    try:
+        s3 = boto3.client('s3')
+        asset_sources = []
+        
+        if not prefixes and not keys:
+            # If no prefixes or keys specified, include entire bucket
+            response = s3.list_objects_v2(Bucket=bucket)
+            for obj in response.get('Contents', []):
+                asset_sources.append({
+                    'Bucket': bucket,
+                    'Key': obj['Key']
+                })
+        else:
+            # Process prefixes
+            for prefix in prefixes:
+                if prefix:
+                    response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)
+                    for obj in response.get('Contents', []):
+                        asset_sources.append({
+                            'Bucket': bucket,
+                            'Key': obj['Key']
+                        })
+            
+            # Add individual keys
+            for key in keys:
+                asset_sources.append({
+                    'Bucket': bucket,
+                    'Key': key
+                })
+
+        # Print assets being added
+        for asset in asset_sources:
+            print(f"Adding asset: s3://{asset['Bucket']}/{asset['Key']}")
+
+        # Create a single job for all assets
+        job_details = {
+            'ImportAssetsFromS3': {
+                'AssetSources': asset_sources,
+                'DataSetId': dataset_id,
+                'RevisionId': revision_id
+            }
+        }
+
+        response = dataexchange.create_job(Type='IMPORT_ASSETS_FROM_S3', Details=job_details)
+        job_id = response['Id']
+        
+        # Wait for job completion
+        job_state = wait_for_job_completion(dataexchange, job_id)
+        if job_state != 'COMPLETED':
+            raise click.ClickException(f"Job failed with state: {job_state}")
+
+        return "All assets added successfully"
+    except ClientError as e:
+        click.echo(f"An error occurred while adding the assets: {e}", err=True)
+        raise
+
+def wait_for_job_completion(dataexchange, job_id):
+    """
+    Wait for a job to complete
+    """
+    dataexchange.start_job(JobId=job_id)
+
+    while True:
+        job_response = dataexchange.get_job(JobId=job_id)
+        job_state = job_response['State']
+
+        if job_state in ['COMPLETED', 'ERROR', 'CANCELLED']:
+            if job_state == 'ERROR':
+                error_details = job_response.get('Errors', [])
+                click.echo(f"Job failed with errors: {error_details}")
+            return job_state
+
+        click.echo(f"Job {job_id} is in {job_state} state. Waiting...")
+        time.sleep(5)
+
+def finalize_revision(dataexchange, dataset_id, revision_id):
+    """
+    Finalize the revision
+    """
+    try:
+        dataexchange.update_revision(DataSetId=dataset_id, RevisionId=revision_id, Finalized=True)
+    except ClientError as e:
+        click.echo(f"An error occurred while finalizing the revision: {e}", err=True)
+        raise
+
+@click.command()
+@click.option('--bucket', required=True, help='S3 bucket name or full S3 URI')
+@click.option('--prefix', multiple=True, help='S3 prefix to include (can be used multiple times)')
+@click.option('--key', multiple=True, help='S3 object key to include (can be used multiple times)')
+@click.option('--dataset-name', required=True, help='Name of the dataset')
+@click.option('--region', default='us-east-1', help='AWS region')
+def main(bucket, prefix, key, dataset_name, region):
+    """
+    Create a dataset and import assets from S3.
+    """
+    # Parse bucket and initial prefix from the provided bucket parameter
+    if bucket.startswith('s3://'):
+        parts = bucket.replace('s3://', '').split('/', 1)
+        bucket_name = parts[0]
+        initial_prefix = parts[1] if len(parts) > 1 else ''
+    else:
+        bucket_name = bucket
+        initial_prefix = ''
+
+    # Combine initial_prefix with provided prefixes
+    all_prefixes = [initial_prefix] if initial_prefix else []
+    all_prefixes.extend(prefix)
+
+    dataexchange = boto3.client('dataexchange', region_name=region)
+    
+    try:
+        # Create dataset
+        dataset_id = create_dataset(dataexchange, dataset_name)
+        click.echo(f"Dataset created successfully. Dataset ID: {dataset_id}")
+
+        # Create revision
+        revision_id = create_revision(dataexchange, dataset_id)
+        click.echo(f"Revision created successfully. Revision ID: {revision_id}")
+
+        # Add assets to revision
+        result = add_asset_to_revision(dataexchange, dataset_id, revision_id, bucket_name, all_prefixes, key)
+        click.echo(result)
+
+        # Finalize revision
+        finalize_revision(dataexchange, dataset_id, revision_id)
+        click.echo("Revision finalized successfully.")
+
+    except Exception as e:
+        click.echo(f"An error occurred: {str(e)}", err=True)
+        raise click.Abort()
+
+if __name__ == "__main__":
+    main()

--- a/providers/python/add-amazon-s3-data-files/requirements.txt
+++ b/providers/python/add-amazon-s3-data-files/requirements.txt
@@ -1,0 +1,3 @@
+boto3>1.35
+botocore>=1.35
+Click>=7.0

--- a/providers/python/create-amazon-s3-files-data-grant/README.md
+++ b/providers/python/create-amazon-s3-files-data-grant/README.md
@@ -1,0 +1,57 @@
+# Create file-based data grant on AWS Data Exchange (Python)
+
+This script automates the process of creating and populating an AWS Data Exchange dataset with files from an S3 bucket. It creates a new dataset, adds specified S3 objects as assets to a new revision within that dataset, and finalizes the revision. Finally, it creates a data grant for the dataset, allowing a specified AWS account to access the data, optionally with an expiration date.
+
+### Setup
+
+Install the requirements:
+
+```bash
+$ pip3 install -r requirements.txt
+```
+
+Set the AWS access key and secret environment variables:
+
+```
+$ export AWS_ACCESS_KEY_ID=<your-access-key-id>
+$ export AWS_SECRET_ACCESS_KEY=<your-secret-access-key>
+$ export AWS_SESSION_TOKEN=<your-session-token>
+```
+
+The user needs the **AWSDataExchangeProviderFullAccess** IAM policy associated with your role/account. Find out more
+about IAM policies on AWS Data Exchange [here](https://docs.aws.amazon.com/data-exchange/latest/userguide/auth-access.html).
+
+The user needs to list and read objects from the specified S3 bucket. You'll need the following S3 permissions:
+- s3:GetObject
+- s3:ListBucket
+
+Here's a sample IAM policy that includes the necessary permissions:
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::your-bucket-name",
+                "arn:aws:s3:::your-bucket-name/*"
+            ]
+        }
+    ]
+}
+```
+### Example Usage
+
+Get usage help: `python3 create-data-grant.py --help`
+
+Create data grant for Amazon S3 Bucket: `python3 create-data-grant.py --dataset-name example_dataset --bucket s3://example-bucket --grant-name example_bucket_grant --grant-end-date 2024-12-01 --target-account-id 123456789012`
+
+Create data grant for prefix(s) within Amazon S3 Bucket: `python3 create-data-grant.py --dataset-name example_prefix_dataset --bucket example-bucket --prefix data/ --grant-name example_prefix_grant --grant-end-date 2024-12-01 --target-account-id 123456789012`
+
+Create data grant for specific key(s) within an Amazon S3 bucket: `python3 create-data-grant.py --dataset-name example_file_dataset --bucket example-bucket --key data/example.parquet --grant-name example_file_grant --grant-end-date 2024-12-01 --target-account-id 123456789012`
+
+**Note**: `grant-end-date` is an optional parameter. If not provided, the grant will not expire.

--- a/providers/python/create-amazon-s3-files-data-grant/create-data-grant.py
+++ b/providers/python/create-amazon-s3-files-data-grant/create-data-grant.py
@@ -1,0 +1,209 @@
+import boto3
+import time
+import click
+from botocore.exceptions import ClientError
+from datetime import datetime, timezone
+
+def create_dataset(dataexchange, dataset_name):
+    """
+    Create a data files delivery method dataset
+    """
+    try:
+        dataset_params = {
+            'AssetType': 'S3_SNAPSHOT',
+            'Description': f'Dataset for {dataset_name}',
+            'Name': dataset_name,
+            'Tags': {
+                'Source': 'S3'
+            }
+        }
+
+        response = dataexchange.create_data_set(**dataset_params)
+        return response['Id']
+    except ClientError as e:
+        click.echo(f"An error occurred while creating the dataset: {e}", err=True)
+        raise
+
+def create_data_grant(dataexchange, dataset_id, grant_name, grant_end_date, target_account_id, grant_description=None):
+    """
+    Create a data grant for the specified dataset
+    """
+    try:
+        grant_params = {
+            'Name': grant_name,
+            'GrantDistributionScope': 'NONE',  # or 'AWS_ORGANIZATION' if applicable
+            'ReceiverPrincipal': target_account_id,
+            'SourceDataSetId': dataset_id,
+            'Description': grant_description or f'Data grant for {grant_name}',
+            'Tags': {
+                'CreatedBy': 'AutomationScript'
+            }
+        }
+        if grant_end_date:
+            grant_params['EndsAt'] = grant_end_date
+        response = dataexchange.create_data_grant(**grant_params)
+        return response['Id']
+    except ClientError as e:
+        click.echo(f"An error occurred while creating the data grant: {e}", err=True)
+        raise
+
+def create_revision(dataexchange, dataset_id):
+    """
+    Create a new revision for the dataset
+    """
+    try:
+        response = dataexchange.create_revision(DataSetId=dataset_id)
+        return response['Id']
+    except ClientError as e:
+        click.echo(f"An error occurred while creating the revision: {e}", err=True)
+        raise
+
+def add_asset_to_revision(dataexchange, dataset_id, revision_id, bucket, prefixes, keys):
+    """
+    Add assets to the revision based on prefixes and keys, or entire bucket if none specified
+    """
+    try:
+        s3 = boto3.client('s3')
+        asset_sources = []
+        
+        if not prefixes and not keys:
+            # If no prefixes or keys specified, include entire bucket
+            response = s3.list_objects_v2(Bucket=bucket)
+            for obj in response.get('Contents', []):
+                asset_sources.append({
+                    'Bucket': bucket,
+                    'Key': obj['Key']
+                })
+        else:
+            # Process prefixes
+            for prefix in prefixes:
+                if prefix:
+                    response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)
+                    for obj in response.get('Contents', []):
+                        asset_sources.append({
+                            'Bucket': bucket,
+                            'Key': obj['Key']
+                        })
+            
+            # Add individual keys
+            for key in keys:
+                asset_sources.append({
+                    'Bucket': bucket,
+                    'Key': key
+                })
+
+        # Print assets being added
+        for asset in asset_sources:
+            print(f"Adding asset: s3://{asset['Bucket']}/{asset['Key']}")
+
+        # Create a single job for all assets
+        job_details = {
+            'ImportAssetsFromS3': {
+                'AssetSources': asset_sources,
+                'DataSetId': dataset_id,
+                'RevisionId': revision_id
+            }
+        }
+
+        response = dataexchange.create_job(Type='IMPORT_ASSETS_FROM_S3', Details=job_details)
+        job_id = response['Id']
+        
+        # Wait for job completion
+        job_state = wait_for_job_completion(dataexchange, job_id)
+        if job_state != 'COMPLETED':
+            raise click.ClickException(f"Job failed with state: {job_state}")
+
+        return "All assets added successfully"
+    except ClientError as e:
+        click.echo(f"An error occurred while adding the assets: {e}", err=True)
+        raise
+
+def wait_for_job_completion(dataexchange, job_id):
+    """
+    Wait for a job to complete
+    """
+    dataexchange.start_job(JobId=job_id)
+
+    while True:
+        job_response = dataexchange.get_job(JobId=job_id)
+        job_state = job_response['State']
+
+        if job_state in ['COMPLETED', 'ERROR', 'CANCELLED']:
+            if job_state == 'ERROR':
+                error_details = job_response.get('Errors', [])
+                click.echo(f"Job failed with errors: {error_details}")
+            return job_state
+
+        click.echo(f"Job {job_id} is in {job_state} state. Waiting...")
+        time.sleep(5)
+
+def finalize_revision(dataexchange, dataset_id, revision_id):
+    """
+    Finalize the revision
+    """
+    try:
+        dataexchange.update_revision(DataSetId=dataset_id, RevisionId=revision_id, Finalized=True)
+    except ClientError as e:
+        click.echo(f"An error occurred while finalizing the revision: {e}", err=True)
+        raise
+
+@click.command()
+@click.option('--bucket', required=True, help='S3 bucket name or full S3 URI')
+@click.option('--prefix', multiple=True, help='S3 prefix to include (can be used multiple times)')
+@click.option('--key', multiple=True, help='S3 object key to include (can be used multiple times)')
+@click.option('--dataset-name', required=True, help='Name of the dataset')
+@click.option('--grant-name', required=True, help='Name of the data grant')
+@click.option('--grant-end-date', type=click.DateTime(formats=["%Y-%m-%d"]), 
+              help='End date for the grant (YYYY-MM-DD). If not provided, grant will not expire.')
+@click.option('--target-account-id', required=True, help='Target AWS account ID')
+@click.option('--region', default='us-east-1', help='AWS region')
+@click.option('--grant-description', help='Custom description for the data grant')
+def main(bucket, prefix, key, dataset_name, grant_name, grant_end_date, target_account_id, region, grant_description):
+    """
+    Create a dataset and data grant based on the provided parameters.
+    """
+    # Parse bucket and initial prefix from the provided bucket parameter
+    if bucket.startswith('s3://'):
+        parts = bucket.replace('s3://', '').split('/', 1)
+        bucket_name = parts[0]
+        initial_prefix = parts[1] if len(parts) > 1 else ''
+    else:
+        bucket_name = bucket
+        initial_prefix = ''
+
+    # Combine initial_prefix with provided prefixes
+    all_prefixes = [initial_prefix] if initial_prefix else []
+    all_prefixes.extend(prefix)
+
+    dataexchange = boto3.client('dataexchange', region_name=region)
+    
+    try:
+        # Create dataset
+        dataset_id = create_dataset(dataexchange, dataset_name)
+        click.echo(f"Dataset created successfully. Dataset ID: {dataset_id}")
+
+        # Create revision
+        revision_id = create_revision(dataexchange, dataset_id)
+        click.echo(f"Revision created successfully. Revision ID: {revision_id}")
+
+        # Add assets to revision
+        result = add_asset_to_revision(dataexchange, dataset_id, revision_id, bucket_name, all_prefixes, key)
+        click.echo(result)
+
+        # Finalize revision
+        finalize_revision(dataexchange, dataset_id, revision_id)
+        click.echo("Revision finalized successfully.")
+
+        # Format the grant_end_date if provided
+        formatted_end_date = grant_end_date.replace(tzinfo=timezone.utc) if grant_end_date else None
+
+        # Create data grant
+        grant_id = create_data_grant(dataexchange, dataset_id, grant_name, formatted_end_date, target_account_id, grant_description)
+        click.echo(f"Data grant created successfully. Grant ID: {grant_id}")
+
+    except Exception as e:
+        click.echo(f"An error occurred: {str(e)}", err=True)
+        raise click.Abort()
+
+if __name__ == "__main__":
+    main()

--- a/providers/python/create-amazon-s3-files-data-grant/requirements.txt
+++ b/providers/python/create-amazon-s3-files-data-grant/requirements.txt
@@ -1,0 +1,3 @@
+boto3>1.35
+botocore>=1.35
+Click>=7.0


### PR DESCRIPTION
# Add Amazon S3 Files Dataset
A Python script that automates AWS Data Exchange dataset creation using S3 bucket content. Creates datasets, generates revisions, and imports assets from S3 buckets, prefixes, or objects through a simple CLI interface.

# Create file-based data grant on AWS Data Exchange
A Python script for automating AWS Data Exchange dataset creation with S3 files. Creates datasets, adds S3 objects as assets, and establishes data grants for specified AWS accounts with optional expiration dates.